### PR TITLE
Add missing abort method to _OpenTracingServicerContext + version bump

### DIFF
--- a/grpc_opentracing/_server.py
+++ b/grpc_opentracing/_server.py
@@ -53,6 +53,11 @@ class _OpenTracingServicerContext(grpc.ServicerContext, ActiveSpanSource):
     def set_trailing_metadata(self, *args, **kwargs):
         return self._servicer_context.set_trailing_metadata(*args, **kwargs)
 
+    def abort(self, *args, **kwargs):
+        if not hasattr(self._servicer_context, 'abort'):
+            raise RuntimeError('abort() is not supported with the installed version of grpcio')
+        return self._servicer_context.abort(*args, **kwargs)
+
     def set_code(self, code):
         self.code = code
         return self._servicer_context.set_code(code)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def readme():
 
 setup(
     name='grpcio-opentracing',
-    version='1.1.0',
+    version='1.1.1',
     description='Python OpenTracing Extensions for gRPC',
     long_description=readme(),
     author='LightStep',


### PR DESCRIPTION
This method was added in grpcio 1.8.0. Let me know if you want me to include the version bump