### PR TITLE
Guarantee that header keys are lowercase as required by the HTTP/2 spec

### DIFF
--- a/grpc_opentracing/_client.py
+++ b/grpc_opentracing/_client.py
@@ -46,7 +46,7 @@ def _inject_span_context(tracer, span, metadata):
         span.log_kv({'event': 'error', 'error.object': e})
         return metadata
     metadata = () if metadata is None else tuple(metadata)
-    return metadata + tuple(iteritems(headers))
+    return metadata + tuple((k.lower(), v) for (k, v) in iteritems(headers))
 
 
 def _make_future_done_callback(span, rpc_info, log_payloads, span_decorator):


### PR DESCRIPTION
Some opentracing tracer implementations specify mixed case headers for propagating their trace context.  HTTP/2 requires that they be lowercase and GRPC rejects headers that contain uppercase letters.  This seemed like the least intrusive place to change the header case - but I'm open to suggestions for better ways to handle this.