### PR TITLE
Add abort_with_status implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements-test.txt" }}
+          - v2-dependencies-{{ checksum "requirements-test.txt" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
 
       - run:
           name: install dependencies
@@ -26,7 +26,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
+          key: v2-dependencies-{{ checksum "requirements-test.txt" }}
         
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   build_python3:
     docker:
-      - image: circleci/python:3.6.1
-      
+      - image: circleci/python:3.6.8
+
     working_directory: ~/repo
 
     steps:
@@ -27,7 +27,7 @@ jobs:
           paths:
             - ./venv
           key: v2-dependencies-{{ checksum "requirements-test.txt" }}
-        
+
       - run:
           name: run tests
           command: |
@@ -37,7 +37,7 @@ jobs:
   build_python2:
     docker:
       - image: circleci/python:2.7.13
-      
+
     working_directory: ~/repo
 
     steps:
@@ -61,7 +61,7 @@ jobs:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements-test.txt" }}
-        
+
       - run:
           name: run tests
           command: |
@@ -71,7 +71,7 @@ jobs:
   deploy:
     docker:
       - image: circleci/python:3.6.1
-      
+
     working_directory: ~/repo
 
     steps:
@@ -95,7 +95,7 @@ jobs:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements-test.txt" }}
-        
+
       - run:
           name: verify git tag vs. version
           command: |

--- a/grpc_opentracing/_server.py
+++ b/grpc_opentracing/_server.py
@@ -58,6 +58,11 @@ class _OpenTracingServicerContext(grpc.ServicerContext, ActiveSpanSource):
             raise RuntimeError('abort() is not supported with the installed version of grpcio')
         return self._servicer_context.abort(*args, **kwargs)
 
+    def abort_with_status(self, *args, **kwargs):
+        if not hasattr(self._servicer_context, 'abort_with_status'):
+            raise RuntimeError('abort_with_status() is not supported with the installed version of grpcio')
+        return self._servicer_context.abort_with_status(*args, **kwargs)
+
     def set_code(self, code):
         self.code = code
         return self._servicer_context.set_code(code)


### PR DESCRIPTION
The `abort_with_status` method was added to the abstract class
`grpc.ServicerContext` in grpc 1.18.0, from which the `_OpenTracingServicerContext`
inherits.
(See https://github.com/grpc/grpc/pull/17481)
If no implementation for the new abstract method is provided, the `_OpenTracingServicerContext` class cannot be instantiated.