### PR TITLE
Adding license information to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,14 @@ setup(
     description='Python OpenTracing Extensions for gRPC',
     long_description=readme(),
     author='LightStep',
-    license='',
+    license='Apache',
     install_requires=['opentracing>=1.2.2', 'grpcio>=1.1.3', 'six>=1.10'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'future'],
     keywords=['opentracing'],
     classifiers=[
         'Operating System :: OS Independent',
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6"


### PR DESCRIPTION
Hi, I've added to the setup.py the missing license information.
I've assumed it is Apache license, since that's what's on the repo right now.
