### PR TITLE
Don't fall back to outdated dependency cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements-test.txt" }}
+          - v1-dependencies-{{ checksum "setup.py" }}
 
       - run:
           name: install dependencies
@@ -24,7 +24,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
+          key: v1-dependencies-{{ checksum "setup.py" }}
         
       - run:
           name: run tests
@@ -44,7 +44,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements-test.txt" }}
+          - v1-dependencies-{{ checksum "setup.py" }}
 
       - run:
           name: install dependencies
@@ -56,7 +56,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
+          key: v1-dependencies-{{ checksum "setup.py" }}
         
       - run:
           name: run tests
@@ -76,7 +76,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements-test.txt" }}
+          - v1-dependencies-{{ checksum "setup.py" }}
          
       - run:
           name: install dependencies
@@ -88,7 +88,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
+          key: v1-dependencies-{{ checksum "setup.py" }}
         
       - run:
           name: verify git tag vs. version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_python3:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6.8
       
     working_directory: ~/repo
 
@@ -34,7 +34,7 @@ jobs:
 
   build_python2:
     docker:
-      - image: circleci/python:2.7.13
+      - image: circleci/python:2.7.16
       
     working_directory: ~/repo
 
@@ -66,7 +66,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6.8
       
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "requirements-test.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
 
       - run:
           name: install dependencies
@@ -47,8 +45,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "requirements-test.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
 
       - run:
           name: install dependencies
@@ -81,9 +77,7 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "requirements-test.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
+         
       - run:
           name: install dependencies
           command: |

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=readme(),
     author='LightStep',
     license='Apache',
-    install_requires=['opentracing>=1.2.2', 'grpcio>=1.1.3', 'six>=1.10'],
+    install_requires=['opentracing>=1.2.2', 'grpcio>=1.1.3,<=1.17.1', 'six>=1.10'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'future'],
     keywords=['opentracing'],


### PR DESCRIPTION
Some outdated cached dependencies are causing builds to fail, as in https://github.com/opentracing-contrib/python-grpc/pull/17